### PR TITLE
Fix environment variables input with user-friendly table interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TypeScript errors with AI SDK message types
   - Updated to use CoreMessage type from AI SDK for proper type safety
   - Fixed incompatible message type errors in streamText responses
+- Environment variables input in MCP settings modal
+  - Replaced error-prone KEY=value textarea with user-friendly table interface
+  - Environment variables can now be added, edited, and removed individually
+  - Clear visual separation between variable names and values
+  - Input validation prevents adding empty keys or values
 
 ## [0.4.0] - 2025-01-29
 

--- a/src/components/EnvVarsTable.test.tsx
+++ b/src/components/EnvVarsTable.test.tsx
@@ -1,0 +1,187 @@
+import { render, screen, fireEvent } from '@testing-library/preact';
+import { EnvVarsTable } from './EnvVarsTable';
+
+describe('EnvVarsTable', () => {
+  const mockOnChange = vi.fn();
+
+  beforeEach(() => {
+    mockOnChange.mockClear();
+  });
+
+  it('renders table with headers', () => {
+    render(<EnvVarsTable env={{}} onChange={mockOnChange} />);
+    
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Value')).toBeInTheDocument();
+  });
+
+  it('renders existing environment variables', () => {
+    const env = {
+      'API_KEY': 'secret-key',
+      'BASE_URL': 'https://api.example.com',
+      'TIMEOUT': '30'
+    };
+    
+    render(<EnvVarsTable env={env} onChange={mockOnChange} />);
+    
+    expect(screen.getByText('API_KEY')).toBeInTheDocument();
+    expect(screen.getByText('secret-key')).toBeInTheDocument();
+    expect(screen.getByText('BASE_URL')).toBeInTheDocument();
+    expect(screen.getByText('https://api.example.com')).toBeInTheDocument();
+    expect(screen.getByText('TIMEOUT')).toBeInTheDocument();
+    expect(screen.getByText('30')).toBeInTheDocument();
+  });
+
+  it('adds new environment variable', () => {
+    render(<EnvVarsTable env={{}} onChange={mockOnChange} />);
+    
+    const keyInput = screen.getByPlaceholderText('KEY');
+    const valueInput = screen.getByPlaceholderText('value');
+    const addButton = screen.getByText('Add');
+    
+    // Initially disabled
+    expect(addButton).toBeDisabled();
+    
+    // Enter key
+    fireEvent.input(keyInput, { target: { value: 'NEW_VAR' } });
+    expect(addButton).toBeDisabled(); // Still disabled without value
+    
+    // Enter value
+    fireEvent.input(valueInput, { target: { value: 'new-value' } });
+    expect(addButton).not.toBeDisabled();
+    
+    // Click add
+    fireEvent.click(addButton);
+    
+    expect(mockOnChange).toHaveBeenCalledWith({
+      'NEW_VAR': 'new-value'
+    });
+  });
+
+  it('clears input fields after adding', () => {
+    render(<EnvVarsTable env={{}} onChange={mockOnChange} />);
+    
+    const keyInput = screen.getByPlaceholderText('KEY') as HTMLInputElement;
+    const valueInput = screen.getByPlaceholderText('value') as HTMLInputElement;
+    const addButton = screen.getByText('Add');
+    
+    fireEvent.input(keyInput, { target: { value: 'TEST_KEY' } });
+    fireEvent.input(valueInput, { target: { value: 'test-value' } });
+    fireEvent.click(addButton);
+    
+    expect(keyInput.value).toBe('');
+    expect(valueInput.value).toBe('');
+  });
+
+  it('removes environment variable', () => {
+    const env = {
+      'KEY1': 'value1',
+      'KEY2': 'value2',
+      'KEY3': 'value3'
+    };
+    
+    render(<EnvVarsTable env={env} onChange={mockOnChange} />);
+    
+    const removeButtons = screen.getAllByText('Remove');
+    expect(removeButtons).toHaveLength(3);
+    
+    // Remove the second item
+    fireEvent.click(removeButtons[1]);
+    
+    expect(mockOnChange).toHaveBeenCalledWith({
+      'KEY1': 'value1',
+      'KEY3': 'value3'
+    });
+  });
+
+  it('trims whitespace from key and value', () => {
+    render(<EnvVarsTable env={{}} onChange={mockOnChange} />);
+    
+    const keyInput = screen.getByPlaceholderText('KEY');
+    const valueInput = screen.getByPlaceholderText('value');
+    const addButton = screen.getByText('Add');
+    
+    fireEvent.input(keyInput, { target: { value: '  PADDED_KEY  ' } });
+    fireEvent.input(valueInput, { target: { value: '  padded-value  ' } });
+    fireEvent.click(addButton);
+    
+    expect(mockOnChange).toHaveBeenCalledWith({
+      'PADDED_KEY': 'padded-value'
+    });
+  });
+
+  it('does not enable add button with only whitespace', () => {
+    render(<EnvVarsTable env={{}} onChange={mockOnChange} />);
+    
+    const keyInput = screen.getByPlaceholderText('KEY');
+    const valueInput = screen.getByPlaceholderText('value');
+    const addButton = screen.getByText('Add');
+    
+    fireEvent.input(keyInput, { target: { value: '   ' } });
+    fireEvent.input(valueInput, { target: { value: '   ' } });
+    
+    expect(addButton).toBeDisabled();
+  });
+
+  it('handles adding to existing environment variables', () => {
+    const env = {
+      'EXISTING': 'value'
+    };
+    
+    render(<EnvVarsTable env={env} onChange={mockOnChange} />);
+    
+    const keyInput = screen.getByPlaceholderText('KEY');
+    const valueInput = screen.getByPlaceholderText('value');
+    const addButton = screen.getByText('Add');
+    
+    fireEvent.input(keyInput, { target: { value: 'NEW_KEY' } });
+    fireEvent.input(valueInput, { target: { value: 'new-value' } });
+    fireEvent.click(addButton);
+    
+    expect(mockOnChange).toHaveBeenCalledWith({
+      'EXISTING': 'value',
+      'NEW_KEY': 'new-value'
+    });
+  });
+
+  it('overwrites existing key when adding duplicate', () => {
+    const env = {
+      'DUPLICATE': 'old-value'
+    };
+    
+    render(<EnvVarsTable env={env} onChange={mockOnChange} />);
+    
+    const keyInput = screen.getByPlaceholderText('KEY');
+    const valueInput = screen.getByPlaceholderText('value');
+    const addButton = screen.getByText('Add');
+    
+    fireEvent.input(keyInput, { target: { value: 'DUPLICATE' } });
+    fireEvent.input(valueInput, { target: { value: 'new-value' } });
+    fireEvent.click(addButton);
+    
+    expect(mockOnChange).toHaveBeenCalledWith({
+      'DUPLICATE': 'new-value'
+    });
+  });
+
+  it('handles null or undefined env prop', () => {
+    render(<EnvVarsTable env={null as any} onChange={mockOnChange} />);
+    
+    // Should render without errors
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Value')).toBeInTheDocument();
+    
+    // Should be able to add new variables
+    const keyInput = screen.getByPlaceholderText('KEY');
+    const valueInput = screen.getByPlaceholderText('value');
+    const addButton = screen.getByText('Add');
+    
+    fireEvent.input(keyInput, { target: { value: 'TEST' } });
+    fireEvent.input(valueInput, { target: { value: 'value' } });
+    fireEvent.click(addButton);
+    
+    expect(mockOnChange).toHaveBeenCalledWith({
+      'TEST': 'value'
+    });
+  });
+});

--- a/src/components/EnvVarsTable.tsx
+++ b/src/components/EnvVarsTable.tsx
@@ -49,7 +49,6 @@ export function EnvVarsTable({ env, onChange }: EnvVarsTableProps) {
               type="text"
               value={newKey}
               onInput={(e) => {
-                console.log(e.currentTarget.value);
                 setNewKey(e.currentTarget.value);
               }}
               placeholder="KEY"


### PR DESCRIPTION
Replace error-prone KEY=value textarea with a structured table in the MCP settings modal. Users can now add, edit, and remove environment variables individually with clear visual separation between names and values.

🤖 Generated with [Claude Code](https://claude.ai/code)