### PR TITLE
When rendering MCPSettingsModal do not make useEffect depend on configuration changes

### DIFF
--- a/src/components/EnvVarsTable.tsx
+++ b/src/components/EnvVarsTable.tsx
@@ -19,7 +19,7 @@ export function EnvVarsTable({ env, onChange }: EnvVarsTableProps) {
         </tr>
       </thead>
       <tbody>
-        {entries.map(([key, value], idx, arr) => (
+        {entries.map(([key, value], idx, _arr) => (
           <tr key={key + idx}>
             <td>
               <label>{key}</label>

--- a/src/components/MCPSettingsModal.tsx
+++ b/src/components/MCPSettingsModal.tsx
@@ -48,7 +48,7 @@ export function MCPSettingsModal({ show, mcpConfiguration, onSave, onCancel }: M
   const [editingServer, setEditingServer] = useState<MCPServer | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // Parse configuration on mount and when props change
+  // Parse configuration
   useEffect(() => {
     if (mcpConfiguration) {
       try {
@@ -108,7 +108,7 @@ export function MCPSettingsModal({ show, mcpConfiguration, onSave, onCancel }: M
         setError('Failed to parse configuration');
       }
     }
-  }, [mcpConfiguration]);
+  });
 
   // Update editing server when selection changes
   useEffect(() => {


### PR DESCRIPTION
State is reset when the modal is not being rendered. Making the useEffect depend on configuration changes mean that after the modal is closed using "cancel", the second time you open it there will be no configuration loaded.

(There is surely a way to prevent parsing the configuration when it has has not changed, but my react-fu is weak)