### PR TITLE
Fix MCP settings persistence and improve transport dropdown UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Environment variables can now be added, edited, and removed individually
   - Clear visual separation between variable names and values
   - Input validation prevents adding empty keys or values
+- MCP configuration disappearing when reopening settings modal
+  - Fixed state initialization to properly restore configuration when modal is shown
+  - Configuration now persists correctly between modal open/close cycles
 
 ## [0.4.0] - 2025-01-29
 


### PR DESCRIPTION
## Summary
- Fixed bug where MCP configuration would disappear when reopening the settings dialog
- Replaced native select element with custom styled dropdown for transport type selection

## Details

### Bug Fix
The MCP settings dialog had a state management issue where configuration would disappear when reopening the modal. This was caused by:
1. The `handleCancel` function clearing all state when closing the modal
2. The configuration parsing effect not re-running when the modal was shown again

The fix ensures configuration is properly parsed every time the modal opens.

### UI Improvement
Replaced the browser's native select element for transport type with a custom dropdown that:
- Matches the application's design language (similar to ModelSelector)
- Includes descriptive text for each transport option
- Has proper hover states and animations
- Supports dark mode

## Test plan
- [x] Open MCP settings and configure a server
- [x] Close the dialog (cancel or save)
- [x] Reopen the dialog - configuration should still be visible
- [x] Test the new transport dropdown in light and dark modes
- [x] Verify all transport types (stdio, HTTP, WebSocket) can be selected

🤖 Generated with [Claude Code](https://claude.ai/code)