### PR TITLE
Add conversation archive functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Archive functionality for conversations
+  - Conversations can now be archived instead of permanently deleted
+  - New "Archive" tab in the conversation list to view archived conversations
+  - Archived conversations can be unarchived to restore them to the active list
+  - Search functionality in the archive tab to easily find archived conversations
+  - Archive option added to conversation dropdown menu
+  - Automatic migration: existing conversations are marked as active when loaded
+
 ### Changed
 - User messages now use markdown rendering to preserve newlines and formatting
   - Multi-line messages display properly with line breaks preserved

--- a/src/App.css
+++ b/src/App.css
@@ -49,6 +49,9 @@ body {
 .conversation-list-header {
   padding: 1rem;
   border-bottom: 1px solid #e0e0e0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .conversation-list-footer {
@@ -1489,5 +1492,95 @@ body {
     background: #4a4a4a;
     border-color: #64b5f6;
     color: #64b5f6;
+  }
+}
+
+/* Conversation Tabs */
+.conversation-tabs {
+  display: flex;
+  gap: 0.5rem;
+  border-bottom: 1px solid #e0e0e0;
+  padding-bottom: 0.5rem;
+}
+
+.conversation-tabs .tab {
+  flex: 1;
+  padding: 0.5rem 1rem;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+  color: #666;
+  transition: all 0.2s;
+}
+
+.conversation-tabs .tab:hover {
+  background: #f0f0f0;
+  color: #333;
+}
+
+.conversation-tabs .tab.active {
+  background: #e3f2fd;
+  color: #0277bd;
+  border-color: #0277bd;
+}
+
+/* Search Box */
+.search-box {
+  width: 100%;
+}
+
+.search-input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.search-input:focus {
+  border-color: #007bff;
+}
+
+.search-input::placeholder {
+  color: #999;
+}
+
+/* Dark mode support for tabs and search */
+@media (prefers-color-scheme: dark) {
+  .conversation-tabs {
+    border-color: #444;
+  }
+
+  .conversation-tabs .tab {
+    color: #999;
+  }
+
+  .conversation-tabs .tab:hover {
+    background: #3a3a3a;
+    color: #e0e0e0;
+  }
+
+  .conversation-tabs .tab.active {
+    background: #1e3a5f;
+    color: #64b5f6;
+    border-color: #64b5f6;
+  }
+
+  .search-input {
+    background: #3a3a3a;
+    border-color: #555;
+    color: #e0e0e0;
+  }
+
+  .search-input:focus {
+    border-color: #64b5f6;
+  }
+
+  .search-input::placeholder {
+    color: #666;
   }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -11,6 +11,8 @@ interface ConversationListProps {
   onCreate: () => void;
   onRename: (id: string, title: string) => void;
   onDelete: (id: string) => void;
+  onArchive: (id: string) => void;
+  onUnarchive: (id: string) => void;
   onSettingsClick: () => void;
 }
 
@@ -45,6 +47,8 @@ vi.mock('./store', () => {
     mcpServers: signal([]),
     createConversation: vi.fn(),
     deleteConversation: vi.fn(),
+    archiveConversation: vi.fn(),
+    unarchiveConversation: vi.fn(),
     updateConversationTitle: vi.fn(),
     addMessage: vi.fn(),
     updateMessage: vi.fn(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,8 @@ import {
   errorMessage,
   createConversation,
   deleteConversation,
+  archiveConversation,
+  unarchiveConversation,
   updateConversationTitle,
   updateConversationModel,
   updateSettings,
@@ -120,6 +122,8 @@ function App() {
             onCreate={createNewConversation}
             onRename={renameConversation}
             onDelete={handleDeleteConversation}
+            onArchive={archiveConversation}
+            onUnarchive={unarchiveConversation}
             onSettingsClick={() => setShowSettings(true)}
             defaultModel={settings.value.defaultModel}
             onDefaultModelChange={handleDefaultModelChange}

--- a/src/components/ConversationList.test.tsx
+++ b/src/components/ConversationList.test.tsx
@@ -34,6 +34,8 @@ describe('ConversationList', () => {
     onCreate: vi.fn(),
     onRename: vi.fn(),
     onDelete: vi.fn(),
+    onArchive: vi.fn(),
+    onUnarchive: vi.fn(),
     onSettingsClick: vi.fn(),
     defaultModel: 'gpt-4',
     onDefaultModelChange: vi.fn()
@@ -83,8 +85,11 @@ describe('ConversationList', () => {
     const menuButtons = container.querySelectorAll('.menu-button');
     fireEvent.click(menuButtons[0]);
     
-    expect(screen.getByText('Rename')).toBeInTheDocument();
-    expect(screen.getByText('Delete')).toBeInTheDocument();
+    const dropdown = container.querySelector('.dropdown-menu');
+    expect(dropdown).toBeInTheDocument();
+    expect(dropdown).toHaveTextContent('Rename');
+    expect(dropdown).toHaveTextContent('Archive');
+    expect(dropdown).toHaveTextContent('Delete');
   });
 
   it('hides dropdown menu when clicking outside', async () => {
@@ -179,6 +184,19 @@ describe('ConversationList', () => {
     fireEvent.click(screen.getByText('Delete'));
     
     expect(mockProps.onDelete).toHaveBeenCalledWith('1');
+  });
+
+  it('calls onArchive when archive is clicked', () => {
+    const { container } = render(<ConversationList {...mockProps} />);
+    
+    const menuButtons = container.querySelectorAll('.menu-button');
+    fireEvent.click(menuButtons[0]);
+    
+    const dropdown = container.querySelector('.dropdown-menu');
+    const archiveButton = dropdown?.querySelector('button:nth-child(2)'); // Archive is second button
+    fireEvent.click(archiveButton!);
+    
+    expect(mockProps.onArchive).toHaveBeenCalledWith('1');
   });
 
   it('renders empty state correctly', () => {

--- a/src/components/ConversationList.tsx
+++ b/src/components/ConversationList.tsx
@@ -41,7 +41,8 @@ export function ConversationList({
   const filteredConversations = useMemo(() => {
     const isArchived = activeTab === 'archived';
     return conversations.filter(conv => {
-      const matchesTab = conv.archived === isArchived;
+      // Handle undefined archived field (treat as not archived)
+      const matchesTab = isArchived ? conv.archived === true : conv.archived !== true;
       const matchesSearch = searchQuery === '' || 
         conv.title.toLowerCase().includes(searchQuery.toLowerCase());
       return matchesTab && matchesSearch;

--- a/src/components/ConversationList.tsx
+++ b/src/components/ConversationList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'preact/hooks';
+import { useEffect, useState, useMemo } from 'preact/hooks';
 import type { Conversation } from '../types';
 import { ModelSelector } from './ModelSelector';
 
@@ -9,6 +9,8 @@ interface ConversationListProps {
   onCreate: () => void;
   onRename: (id: string, newTitle: string) => void;
   onDelete: (id: string) => void;
+  onArchive: (id: string) => void;
+  onUnarchive: (id: string) => void;
   onSettingsClick: () => void;
   defaultModel?: string;
   onDefaultModelChange: (modelId: string) => void;
@@ -21,6 +23,8 @@ export function ConversationList({
   onCreate,
   onRename,
   onDelete,
+  onArchive,
+  onUnarchive,
   onSettingsClick,
   defaultModel,
   onDefaultModelChange
@@ -30,6 +34,19 @@ export function ConversationList({
   const [dropdownId, setDropdownId] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editTitle, setEditTitle] = useState('');
+  const [activeTab, setActiveTab] = useState<'active' | 'archived'>('active');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Filter conversations based on tab and search query
+  const filteredConversations = useMemo(() => {
+    const isArchived = activeTab === 'archived';
+    return conversations.filter(conv => {
+      const matchesTab = conv.archived === isArchived;
+      const matchesSearch = searchQuery === '' || 
+        conv.title.toLowerCase().includes(searchQuery.toLowerCase());
+      return matchesTab && matchesSearch;
+    });
+  }, [conversations, activeTab, searchQuery]);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -83,9 +100,40 @@ export function ConversationList({
             </svg>
           </button>
         </div>
+        <div class="conversation-tabs">
+          <button
+            class={`tab ${activeTab === 'active' ? 'active' : ''}`}
+            onClick={() => {
+              setActiveTab('active');
+              setSearchQuery('');
+            }}
+          >
+            Active
+          </button>
+          <button
+            class={`tab ${activeTab === 'archived' ? 'active' : ''}`}
+            onClick={() => {
+              setActiveTab('archived');
+              setSearchQuery('');
+            }}
+          >
+            Archive
+          </button>
+        </div>
+        {activeTab === 'archived' && (
+          <div class="search-box">
+            <input
+              type="text"
+              placeholder="Search archived conversations..."
+              value={searchQuery}
+              onInput={(e) => setSearchQuery(e.currentTarget.value)}
+              class="search-input"
+            />
+          </div>
+        )}
       </div>
       <div class="conversations">
-        {conversations.map((conversation) => (
+        {filteredConversations.map((conversation) => (
           <div
             key={conversation.id}
             class={`conversation-item ${selectedId === conversation.id ? 'selected' : ''}`}
@@ -129,6 +177,15 @@ export function ConversationList({
                       <button onClick={() => handleRename(conversation)}>
                         Rename
                       </button>
+                      {conversation.archived ? (
+                        <button onClick={() => onUnarchive(conversation.id)}>
+                          Unarchive
+                        </button>
+                      ) : (
+                        <button onClick={() => onArchive(conversation.id)}>
+                          Archive
+                        </button>
+                      )}
                       <button onClick={() => handleDelete(conversation.id)}>
                         Delete
                       </button>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -156,10 +156,33 @@ export function deleteConversation(id: string) {
   batch(() => {
     conversations.value = conversations.value.filter((c) => c.id !== id);
     if (selectedConversationId.value === id) {
+      // Find first non-archived conversation, or any conversation if all are archived
+      const activeConversations = conversations.value.filter(c => !c.archived);
       selectedConversationId.value =
-        conversations.value.length > 0 ? conversations.value[0].id : null;
+        activeConversations.length > 0 ? activeConversations[0].id :
+          conversations.value.length > 0 ? conversations.value[0].id : null;
     }
   });
+}
+
+export function archiveConversation(id: string) {
+  batch(() => {
+    conversations.value = conversations.value.map((c) =>
+      c.id === id ? { ...c, archived: true, archivedAt: Date.now(), updatedAt: Date.now() } : c
+    );
+    
+    // If archiving the selected conversation, select another active one
+    if (selectedConversationId.value === id) {
+      const activeConversations = conversations.value.filter(c => !c.archived && c.id !== id);
+      selectedConversationId.value = activeConversations.length > 0 ? activeConversations[0].id : null;
+    }
+  });
+}
+
+export function unarchiveConversation(id: string) {
+  conversations.value = conversations.value.map((c) =>
+    c.id === id ? { ...c, archived: false, archivedAt: undefined, updatedAt: Date.now() } : c
+  );
 }
 
 export function updateConversationTitle(id: string, title: string) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,8 @@ export interface Conversation {
   model?: string;
   enabledTools?: { [serverId: string]: string[] }; // serverId -> array of enabled tool names
   sdkMessages?: CoreMessage[];
+  archived?: boolean;
+  archivedAt?: number;
 }
 
 export interface Model {

--- a/src/utils/storage.test.ts
+++ b/src/utils/storage.test.ts
@@ -55,7 +55,8 @@ describe('Storage utilities (deprecated)', () => {
       const result = loadConversations();
       
       expect(localStorage.getItem).toHaveBeenCalledWith('chatalyst_conversations');
-      expect(result).toEqual(mockConversations);
+      // Migration adds archived: false to conversations without the field
+      expect(result).toEqual(mockConversations.map(conv => ({ ...conv, archived: false })));
     });
 
     it('handles invalid JSON gracefully', () => {
@@ -84,6 +85,20 @@ describe('Storage utilities (deprecated)', () => {
       const result = loadConversations();
       
       expect(result).toEqual([]);
+    });
+
+    it('migrates conversations without archived field', () => {
+      const conversationsWithArchived = [
+        { ...mockConversations[0], archived: true },
+        mockConversations[1] // No archived field
+      ];
+      
+      localStorage.getItem.mockReturnValue(JSON.stringify(conversationsWithArchived));
+      
+      const result = loadConversations();
+      
+      expect(result[0].archived).toBe(true); // Keeps existing archived value
+      expect(result[1].archived).toBe(false); // Adds archived: false
     });
   });
 
@@ -167,7 +182,8 @@ describe('Storage utilities (deprecated)', () => {
       // Load conversations
       const loaded = loadConversations();
       
-      expect(loaded).toEqual(mockConversations);
+      // Migration adds archived: false to conversations without the field
+      expect(loaded).toEqual(mockConversations.map(conv => ({ ...conv, archived: false })));
     });
   });
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -7,7 +7,17 @@ const SELECTED_CONVERSATION_KEY = 'chatalyst_selected_conversation';
 export function loadConversations(): Conversation[] {
   try {
     const data = localStorage.getItem(STORAGE_KEY);
-    return data ? JSON.parse(data) : [];
+    if (!data) return [];
+    
+    const conversations: Conversation[] = JSON.parse(data);
+    
+    // Migrate conversations without archived field - set them as active
+    return conversations.map(conv => {
+      if (conv.archived === undefined) {
+        return { ...conv, archived: false };
+      }
+      return conv;
+    });
   } catch (error) {
     showError(`Failed to load conversations from storage: ${error instanceof Error ? error.message : 'Unknown error'}. Your conversations may not be available.`);
     return [];


### PR DESCRIPTION
## Summary
- Added conversation archive functionality to allow users to archive conversations instead of permanently deleting them
- Implemented tabbed interface with Active and Archive tabs in the conversation list
- Added search functionality for finding archived conversations

## Changes
- **Data Model**: Added `archived` and `archivedAt` fields to the Conversation type
- **Store**: Added `archiveConversation()` and `unarchiveConversation()` functions with proper state management
- **UI Components**: 
  - Added tabs (Active/Archive) to ConversationList component
  - Added search box for filtering archived conversations
  - Updated dropdown menu to include Archive/Unarchive options
- **Migration**: Automatically migrates existing conversations to active status on load
- **Styling**: Added CSS for tabs and search with full dark mode support

## Test Plan
- [x] Archive a conversation and verify it moves to the Archive tab
- [x] Unarchive a conversation and verify it returns to the Active tab
- [x] Use search in the Archive tab to filter conversations
- [x] Verify existing conversations appear in Active tab after update
- [x] Test dark mode styling for all new UI elements
- [x] Verify that archiving the selected conversation auto-selects another active one

🤖 Generated with [Claude Code](https://claude.ai/code)