### PR TITLE
feat: Add AI-powered conversation title generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - User messages support markdown formatting like bold, italic, and code blocks
   - Added appropriate CSS styling for markdown elements in user messages
 
+### Changed
+- Enhanced dropdown menu with outline icons
+  - Added Heroicons-style outline icons to all menu items
+  - Icons automatically adapt to light/dark mode using currentColor
+  - Improved visual hierarchy and clarity of menu actions
+
 ### Fixed
 - Fixed dropdown menu styling to prevent text wrapping
   - Increased minimum width from 120px to 150px

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added appropriate CSS styling for markdown elements in user messages
 
 ### Fixed
+- Fixed dropdown menu styling to prevent text wrapping
+  - Increased minimum width from 120px to 150px
+  - Added white-space: nowrap to menu buttons
+  - "Generate Title" option now displays on a single line
 - Fixed race condition where auto-scroll to new user messages would sometimes fail
   - Messages now reliably scroll to top of viewport when sent
   - Added retry logic to handle DOM update timing issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Automatic conversation title generation
+  - New "Generate Title" option in conversation dropdown menu
+  - AI-powered title generation based on conversation content
+  - Shows loading indicator while title is being generated
+  - Only available for conversations with at least one message
 - Archive functionality for conversations
   - Conversations can now be archived instead of permanently deleted
   - New "Archive" tab in the conversation list to view archived conversations

--- a/src/App.css
+++ b/src/App.css
@@ -147,7 +147,7 @@ body {
   border-radius: 0.375rem;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   z-index: 10;
-  min-width: 120px;
+  min-width: 150px;
 }
 
 .dropdown-menu button {
@@ -161,6 +161,7 @@ body {
   font-size: 0.875rem;
   color: #333;
   transition: background-color 0.2s;
+  white-space: nowrap;
 }
 
 .dropdown-menu button:hover {

--- a/src/App.css
+++ b/src/App.css
@@ -151,7 +151,9 @@ body {
 }
 
 .dropdown-menu button {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   width: 100%;
   padding: 0.5rem 1rem;
   border: none;
@@ -162,6 +164,12 @@ body {
   color: #333;
   transition: background-color 0.2s;
   white-space: nowrap;
+}
+
+.dropdown-menu .menu-icon {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
 }
 
 .dropdown-menu button:hover {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ function App() {
   const [showRightSidebar, setShowRightSidebar] = useState(true);
   
   // Custom hooks
-  const { sendMessage, stopGeneration } = useMessageHandling();
+  const { sendMessage, stopGeneration, generateConversationTitle } = useMessageHandling();
   
   // Conversation management
   const createNewConversation = () => {
@@ -59,6 +59,10 @@ function App() {
 
   const handleDeleteConversation = (id: string) => {
     deleteConversation(id);
+  };
+
+  const handleGenerateTitle = async (id: string) => {
+    await generateConversationTitle(id);
   };
 
   // Settings management
@@ -124,6 +128,7 @@ function App() {
             onDelete={handleDeleteConversation}
             onArchive={archiveConversation}
             onUnarchive={unarchiveConversation}
+            onGenerateTitle={handleGenerateTitle}
             onSettingsClick={() => setShowSettings(true)}
             defaultModel={settings.value.defaultModel}
             onDefaultModelChange={handleDefaultModelChange}

--- a/src/components/ConversationList.tsx
+++ b/src/components/ConversationList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo } from 'preact/hooks';
 import type { Conversation } from '../types';
 import { ModelSelector } from './ModelSelector';
+import { generatingTitleFor } from '../store';
 
 interface ConversationListProps {
   conversations: Conversation[];
@@ -11,6 +12,7 @@ interface ConversationListProps {
   onDelete: (id: string) => void;
   onArchive: (id: string) => void;
   onUnarchive: (id: string) => void;
+  onGenerateTitle: (id: string) => void;
   onSettingsClick: () => void;
   defaultModel?: string;
   onDefaultModelChange: (modelId: string) => void;
@@ -25,6 +27,7 @@ export function ConversationList({
   onDelete,
   onArchive,
   onUnarchive,
+  onGenerateTitle,
   onSettingsClick,
   defaultModel,
   onDefaultModelChange
@@ -161,7 +164,11 @@ export function ConversationList({
                   class="conversation-title"
                   onClick={() => onSelect(conversation.id)}
                 >
-                  {conversation.title}
+                  {generatingTitleFor.value === conversation.id ? (
+                    <span style="opacity: 0.6">Generating title...</span>
+                  ) : (
+                    conversation.title
+                  )}
                 </div>
                 <div class="conversation-menu">
                   <button
@@ -178,6 +185,14 @@ export function ConversationList({
                       <button onClick={() => handleRename(conversation)}>
                         Rename
                       </button>
+                      {conversation.messages.length > 0 && (
+                        <button onClick={() => {
+                          onGenerateTitle(conversation.id);
+                          setDropdownId(null);
+                        }}>
+                          Generate Title
+                        </button>
+                      )}
                       {conversation.archived ? (
                         <button onClick={() => onUnarchive(conversation.id)}>
                           Unarchive

--- a/src/components/ConversationList.tsx
+++ b/src/components/ConversationList.tsx
@@ -183,6 +183,9 @@ export function ConversationList({
                   {dropdownId === conversation.id && (
                     <div class="dropdown-menu">
                       <button onClick={() => handleRename(conversation)}>
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="menu-icon">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+                        </svg>
                         Rename
                       </button>
                       {conversation.messages.length > 0 && (
@@ -190,19 +193,31 @@ export function ConversationList({
                           onGenerateTitle(conversation.id);
                           setDropdownId(null);
                         }}>
+                          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="menu-icon">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z" />
+                          </svg>
                           Generate Title
                         </button>
                       )}
                       {conversation.archived ? (
                         <button onClick={() => onUnarchive(conversation.id)}>
+                          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="menu-icon">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="m20.25 7.5-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5m6 4.125 2.25 2.25m0 0 2.25 2.25M12 13.875l2.25-2.25M12 13.875l-2.25 2.25M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" />
+                          </svg>
                           Unarchive
                         </button>
                       ) : (
                         <button onClick={() => onArchive(conversation.id)}>
+                          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="menu-icon">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="m20.25 7.5-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" />
+                          </svg>
                           Archive
                         </button>
                       )}
                       <button onClick={() => handleDelete(conversation.id)}>
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="menu-icon">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                        </svg>
                         Delete
                       </button>
                     </div>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -32,6 +32,7 @@ export const selectedConversationId = signal<string | null>(null);
 export const settings = signal<Settings>(DEFAULT_SETTINGS);
 export const isLoadingModels = signal(false);
 export const isStreaming = signal(false);
+export const generatingTitleFor = signal<string | null>(null);
 
 // Error state signals
 export const errorMessage = signal<string | null>(null);


### PR DESCRIPTION
## Summary

This PR adds an AI-powered conversation title generation feature that allows users to automatically generate titles for their conversations based on the conversation content.

## Changes

- Added `generateConversationTitle` function in `useMessageHandling` hook that:
  - Analyzes the first 10 messages of a conversation
  - Uses the conversation's selected AI model (or default) to generate a concise 3-5 word title
  - Handles errors silently to avoid disrupting the user experience

- Added UI integration:
  - "Generate Title" option in the conversation dropdown menu (only shows for conversations with messages)
  - Loading state that displays "Generating title..." while the AI processes
  - Seamless title update when generation completes

- Added `generatingTitleFor` signal to track loading state per conversation

## Testing

- Tested with conversations of various lengths
- Verified loading states display correctly
- Confirmed error handling doesn't break the UI
- Ensured existing rename functionality still works

## Screenshots

The "Generate Title" option appears in the dropdown menu:
- Only visible when conversation has at least one message
- Shows loading text while generating
- Updates title automatically when complete

🤖 Generated with [Claude Code](https://claude.ai/code)