### PR TITLE
Add copy button to assistant messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Clicking retry removes all subsequent messages and regenerates the assistant response
   - Always visible for better discoverability
   - Includes hover and active state animations for better user feedback
+- Copy button for assistant messages
+  - Copy button with clipboard icon appears next to timestamp on assistant messages
+  - Clicking copies the message content to system clipboard
+  - Always visible for easy access to assistant responses
+  - Includes hover and active state animations for better user feedback
 
 ### Fixed
 - Improved stop generation functionality

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,7 +38,8 @@ export default [
         clearInterval: 'readonly',
         AbortController: 'readonly',
         KeyboardEvent: 'readonly',
-        URL: 'readonly'
+        URL: 'readonly',
+        navigator: 'readonly'
       }
     },
     plugins: {

--- a/src/App.css
+++ b/src/App.css
@@ -695,6 +695,31 @@ body {
   transform: rotate(180deg);
 }
 
+.message-copy-button {
+  background: none;
+  border: none;
+  font-size: 1rem;
+  color: #666;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  transition: all 0.2s;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.message-copy-button:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+  color: #333;
+  transform: scale(1.1);
+}
+
+.message-copy-button:active {
+  transform: scale(0.95);
+}
+
 /* Scroll to bottom button */
 .scroll-to-bottom {
   position: sticky;
@@ -1469,6 +1494,15 @@ body {
   .message-send-button.stopping {
     background: #c53030;
     opacity: 0.8;
+  }
+
+  .message-copy-button {
+    color: #999;
+  }
+
+  .message-copy-button:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+    color: #e0e0e0;
   }
 
   /* Provider Selector Dark Mode */

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -140,7 +140,7 @@ export function Message({ message, collapsed = true, onRetry }: MessageProps) {
             aria-label="Copy message content"
             title="Copy message content"
           >
-            📋
+            ⧉
           </button>
         )}
       </div>

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -30,6 +30,14 @@ export function Message({ message, collapsed = true, onRetry }: MessageProps) {
     return frames[animationFrame];
   };
 
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(message.content);
+    } catch (err) {
+      console.error('Failed to copy message:', err);
+    }
+  };
+
   const renderContent = () => {
     if (message.role === 'tool') {
       return (
@@ -123,6 +131,16 @@ export function Message({ message, collapsed = true, onRetry }: MessageProps) {
             title="Retry from this message"
           >
             ↻
+          </button>
+        )}
+        {message.role === 'assistant' && (
+          <button
+            class="message-copy-button"
+            onClick={handleCopy}
+            aria-label="Copy message content"
+            title="Copy message content"
+          >
+            📋
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Add copy button with black and white icon next to timestamp on assistant messages
- Allow users to copy assistant message content to system clipboard
- Always visible for easy access to assistant responses
- Maintain consistent styling with existing retry button

## Changes
- **Message.tsx**: Added copy button functionality using clipboard API
- **App.css**: Added styling for copy button with hover/active states and dark mode support
- **eslint.config.js**: Added navigator global for clipboard API access
- **CHANGELOG.md**: Updated with user-facing feature description

## Test plan
- [x] Verify copy button appears only on assistant messages
- [x] Test copy functionality works correctly
- [x] Check button styling matches existing pattern
- [x] Confirm dark mode support works
- [x] Run full test suite and linting

🤖 Generated with [Claude Code](https://claude.ai/code)