### PR TITLE
Fix retry functionality issue with SDK message context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Includes hover and active state animations for better user feedback
 
 ### Fixed
+- Retry functionality now properly regenerates responses
+  - Fixed issue where retry would remove messages but not generate new response
+  - Retry now correctly reconstructs conversation context from filtered messages
+  - Ensures AI receives clean conversation history up to retry point only
+
+### Fixed
 - Improved stop generation functionality
   - Stop button now properly cancels AI responses with visual feedback
   - Shows "Stopping..." state while cancellation is in progress


### PR DESCRIPTION
## Summary
- Fix retry button removing messages but not generating new response
- Always reconstruct conversation context from filtered UI messages for retry
- Ensures AI receives clean conversation history up to retry point only

## Problem
The retry functionality was experiencing an issue where:
1. Messages were correctly removed from the UI after the retry point
2. However, the AI was still receiving the full conversation history including previous responses
3. This caused the AI to generate minimal responses (3 tokens) that were then removed as "empty"
4. Result: retry appeared to do nothing

## Root Cause
The retry logic was using `conversation.sdkMessages` which contained the full conversation history, rather than reconstructing the message context from the filtered UI messages.

## Solution
- Modified retry to always reconstruct conversation messages from scratch
- Uses filtered UI messages up to the retry point only
- Ensures AI receives clean conversation context without previous responses
- Removed debug logging statements

## Test plan
- [x] Verify retry button appears on user messages
- [x] Test retry functionality removes subsequent messages
- [x] Confirm new assistant response generates correctly (full response, not 3 tokens)
- [x] Check that AI only sees conversation up to retry point
- [x] Verify proper message context reconstruction
- [x] Run lint and type checking

🤖 Generated with [Claude Code](https://claude.ai/code)