### PR TITLE
Add delete button to user messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Clicking copies the message content to system clipboard
   - Always visible for easy access to assistant responses
   - Includes hover and active state animations for better user feedback
+- Delete button for user messages
+  - Delete button with trash icon appears next to retry button on user messages
+  - Clicking delete removes the selected message and all messages after it
+  - Includes confirmation dialog to prevent accidental deletions
+  - Uses neutral black and white styling to match existing UI design
 - New SSE transport type for MCP servers
   - Added dedicated Server-Sent Events (SSE) transport option in MCP settings
   - SSE transport uses specialized TauriSSESimulatedTransport to handle EventSource authentication limitations

--- a/src/App.css
+++ b/src/App.css
@@ -695,6 +695,98 @@ body {
   transform: rotate(180deg);
 }
 
+.message-delete-button {
+  background: none;
+  border: none;
+  font-size: 1rem;
+  color: #666;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  transition: all 0.2s;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.message-delete-button:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+  color: #333;
+}
+
+.message-delete-button:active {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.delete-confirm-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.delete-confirm-dialog {
+  background: white;
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  max-width: 400px;
+  width: 90%;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.delete-confirm-dialog h3 {
+  margin: 0 0 1rem 0;
+  font-size: 1.1rem;
+  color: #333;
+}
+
+.delete-confirm-dialog p {
+  margin: 0 0 1.5rem 0;
+  color: #666;
+  line-height: 1.4;
+}
+
+.delete-confirm-buttons {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.delete-confirm-cancel,
+.delete-confirm-ok {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+  transition: background-color 0.2s;
+}
+
+.delete-confirm-cancel {
+  background-color: #f5f5f5;
+  color: #666;
+}
+
+.delete-confirm-cancel:hover {
+  background-color: #e5e5e5;
+}
+
+.delete-confirm-ok {
+  background-color: #333;
+  color: white;
+}
+
+.delete-confirm-ok:hover {
+  background-color: #555;
+}
+
 .message-copy-button {
   background: none;
   border: none;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,8 @@ import {
   updateConversationTitle,
   updateConversationModel,
   updateSettings,
-  clearError
+  clearError,
+  deleteMessage
 } from './store';
 import { restartMCPConnections } from './utils/mcp';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
@@ -59,6 +60,12 @@ function App() {
 
   const handleDeleteConversation = (id: string) => {
     deleteConversation(id);
+  };
+
+  const handleDeleteMessage = (messageId: string) => {
+    const conversation = selectedConversation.value;
+    if (!conversation) return;
+    deleteMessage(conversation.id, messageId);
   };
 
   const handleGenerateTitle = async (id: string) => {
@@ -164,6 +171,7 @@ function App() {
             conversation={selectedConversation.value || null}
             onSendMessage={sendMessage}
             onRetryMessage={retryMessage}
+            onDeleteMessage={handleDeleteMessage}
             onModelChange={handleConversationModelChange}
             onStopGeneration={stopGeneration}
           />

--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -9,11 +9,12 @@ interface ConversationProps {
   conversation: ConversationType | null;
   onSendMessage: (message: string) => void;
   onRetryMessage: (messageId: string) => void;
+  onDeleteMessage: (messageId: string) => void;
   onModelChange: (modelId: string) => void;
   onStopGeneration?: () => void;
 }
 
-export function Conversation({ conversation, onSendMessage, onRetryMessage, onModelChange, onStopGeneration }: ConversationProps) {
+export function Conversation({ conversation, onSendMessage, onRetryMessage, onDeleteMessage, onModelChange, onStopGeneration }: ConversationProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const [showScrollButton, setShowScrollButton] = useState(false);
@@ -22,6 +23,11 @@ export function Conversation({ conversation, onSendMessage, onRetryMessage, onMo
   const handleRetry = (messageId: string) => {
     if (!conversation) return;
     onRetryMessage(messageId);
+  };
+
+  const handleDelete = (messageId: string) => {
+    if (!conversation) return;
+    onDeleteMessage(messageId);
   };
 
   // Check if user is at the bottom of scroll (checking against last message, not padding)
@@ -196,6 +202,7 @@ export function Conversation({ conversation, onSendMessage, onRetryMessage, onMo
               key={message.id} 
               message={message}
               onRetry={() => handleRetry(message.id)}
+              onDelete={() => handleDelete(message.id)}
             />
           ))}
           <div ref={messagesEndRef} />

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -6,11 +6,13 @@ interface MessageProps {
   message: MessageType;
   collapsed?: boolean;
   onRetry?: () => void;
+  onDelete?: () => void;
 }
 
-export function Message({ message, collapsed = true, onRetry }: MessageProps) {
+export function Message({ message, collapsed = true, onRetry, onDelete }: MessageProps) {
   const [animationFrame, setAnimationFrame] = useState(0);
   const [isCollapsed, setIsCollapsed] = useState(message.role === 'tool' ? true : collapsed);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   useEffect(() => {
     if (message.isGenerating) {
@@ -36,6 +38,26 @@ export function Message({ message, collapsed = true, onRetry }: MessageProps) {
     } catch (err) {
       console.error('Failed to copy message:', err);
     }
+  };
+
+  const handleDelete = () => {
+    console.log('Delete button clicked', { messageId: message.id, onDelete: !!onDelete });
+    if (onDelete) {
+      setShowDeleteConfirm(true);
+    }
+  };
+
+  const confirmDelete = () => {
+    console.log('User confirmed deletion, calling onDelete');
+    setShowDeleteConfirm(false);
+    if (onDelete) {
+      onDelete();
+    }
+  };
+
+  const cancelDelete = () => {
+    console.log('User cancelled deletion');
+    setShowDeleteConfirm(false);
   };
 
   const renderContent = () => {
@@ -133,6 +155,16 @@ export function Message({ message, collapsed = true, onRetry }: MessageProps) {
             ↻
           </button>
         )}
+        {message.role === 'user' && onDelete && (
+          <button
+            class="message-delete-button"
+            onClick={handleDelete}
+            aria-label="Delete this message and all following messages"
+            title="Delete this message and all following messages"
+          >
+            🗑️
+          </button>
+        )}
         {message.role === 'assistant' && (
           <button
             class="message-copy-button"
@@ -144,6 +176,22 @@ export function Message({ message, collapsed = true, onRetry }: MessageProps) {
           </button>
         )}
       </div>
+      {showDeleteConfirm && (
+        <div class="delete-confirm-overlay">
+          <div class="delete-confirm-dialog">
+            <h3>Confirm Deletion</h3>
+            <p>Delete this message and all messages after it? This cannot be undone.</p>
+            <div class="delete-confirm-buttons">
+              <button class="delete-confirm-cancel" onClick={cancelDelete}>
+                Cancel
+              </button>
+              <button class="delete-confirm-ok" onClick={confirmDelete}>
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -248,6 +248,26 @@ export function removeMessagesAfter(conversationId: string, timestamp: number) {
   );
 }
 
+export function deleteMessage(conversationId: string, messageId: string) {
+  conversations.value = conversations.value.map((c) => {
+    if (c.id !== conversationId) return c;
+    
+    const targetMessage = c.messages.find(m => m.id === messageId);
+    if (!targetMessage) return c;
+    
+    return {
+      ...c,
+      messages: c.messages.filter((m) => m.timestamp < targetMessage.timestamp),
+      sdkMessages: c.sdkMessages?.filter((_, index) => {
+        // Keep SDK messages up to but excluding the target message
+        const messageIndex = c.messages.findIndex(m => m.id === messageId);
+        return messageIndex !== -1 && index < messageIndex;
+      }),
+      updatedAt: Date.now()
+    };
+  });
+}
+
 export function updateSettings(updates: Partial<Settings>) {
   settings.value = { ...settings.value, ...updates };
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Add delete button with trash icon next to retry button on user messages
- Allow users to delete selected message and all subsequent messages
- Include custom confirmation dialog to prevent accidental deletions
- Use neutral black and white styling to match existing UI design

## Test plan
- [x] Verify delete button appears on user messages only
- [x] Test delete functionality removes selected and subsequent messages
- [x] Confirm custom confirmation dialog works properly
- [x] Check button styling and hover states
- [x] Run full test suite and linting
- [x] Manual testing in development environment

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)