### PR TITLE
feat: Add drag and drop functionality for conversation reordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Drag and drop functionality for reordering conversations in the sidebar
+  - Visual drag handle icon for each conversation item
+  - Smooth animations during drag operations
+  - Persistent conversation ordering across sessions
+  - Support for both active and archived conversations
+  - Dark mode support for drag and drop visual feedback
 - Claude Code linting hook that automatically runs ESLint on TypeScript/JavaScript files after edits
 - Streamlined prompt picker with recent prompts access
   - Quick dropdown showing last 5 used prompts for easy reuse

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-shell": "^2.2.1",
     "@tauri-apps/plugin-sql": "^2.3.0",
+    "@types/sortablejs": "^1.15.8",
     "ai": "4.3.16",
     "marked": "^15.0.12",
-    "preact": "^10.25.1"
+    "preact": "^10.25.1",
+    "sortablejs": "^1.15.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@tauri-apps/plugin-sql':
         specifier: ^2.3.0
         version: 2.3.0
+      '@types/sortablejs':
+        specifier: ^1.15.8
+        version: 1.15.8
       ai:
         specifier: 4.3.16
         version: 4.3.16(react@19.1.0)(zod@3.25.32)
@@ -47,6 +50,9 @@ importers:
       preact:
         specifier: ^10.25.1
         version: 10.26.6
+      sortablejs:
+        specifier: ^1.15.6
+        version: 1.15.6
     devDependencies:
       '@eslint/js':
         specifier: ^9.27.0
@@ -879,6 +885,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/sortablejs@1.15.8':
+    resolution: {integrity: sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg==}
 
   '@typescript-eslint/eslint-plugin@8.32.1':
     resolution: {integrity: sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==}
@@ -2190,6 +2199,9 @@ packages:
     resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
     engines: {node: '>=18'}
 
+  sortablejs@1.15.6:
+    resolution: {integrity: sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3220,6 +3232,8 @@ snapshots:
   '@types/estree@1.0.7': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/sortablejs@1.15.8': {}
 
   '@typescript-eslint/eslint-plugin@8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.6.3))(eslint@9.27.0(jiti@2.4.2))(typescript@5.6.3)':
     dependencies:
@@ -4655,6 +4669,8 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+
+  sortablejs@1.15.6: {}
 
   source-map-js@1.2.1: {}
 

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -203,6 +203,17 @@ pub fn get_migrations() -> Vec<Migration> {
             UPDATE prompts SET last_used_at = updated_at WHERE last_used_at IS NULL;",
             kind: MigrationKind::Up,
         },
+        Migration {
+            version: 16,
+            description: "Add display_order column to conversations table for drag and drop ordering",
+            sql: "ALTER TABLE conversations ADD COLUMN display_order INTEGER DEFAULT 0;
+            UPDATE conversations SET display_order = (
+                SELECT COUNT(*) 
+                FROM conversations c2 
+                WHERE c2.updated_at >= conversations.updated_at
+            );",
+            kind: MigrationKind::Up,
+        },
     ]
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -91,6 +91,7 @@ body {
   border-bottom: 1px solid #f0f0f0;
   transition: background-color 0.2s;
   position: relative;
+  user-select: none;
 }
 
 .conversation-item:hover {
@@ -182,6 +183,48 @@ body {
 
 .dropdown-menu button:last-child {
   border-radius: 0 0 0.375rem 0.375rem;
+}
+
+/* Drag and Drop Styles */
+.drag-handle {
+  width: 24px;
+  height: 24px;
+  margin-right: 0.5rem;
+  cursor: grab;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.3;
+  transition: opacity 0.2s;
+}
+
+.drag-handle:hover {
+  opacity: 0.7;
+}
+
+.drag-handle:active {
+  cursor: grabbing;
+}
+
+.drag-icon {
+  width: 16px;
+  height: 16px;
+}
+
+/* Sortable drag states */
+.conversation-drag-ghost {
+  opacity: 0.4;
+  background: #f0f0f0;
+}
+
+.conversation-drag-chosen {
+  opacity: 0.6;
+  background: #e3f2fd;
+}
+
+.conversation-drag-active {
+  background: #ffffff;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.15);
 }
 
 /* Sidebar Toggle Styles */
@@ -1554,6 +1597,24 @@ body {
   .menu-button:hover,
   .settings-button:hover {
     background: #4a4a4a;
+  }
+  
+  /* Dark mode drag handle styles */
+  .drag-handle {
+    color: #e0e0e0;
+  }
+  
+  .conversation-drag-ghost {
+    background: #2a2a2a;
+  }
+  
+  .conversation-drag-chosen {
+    background: #1e3a5f;
+  }
+  
+  .conversation-drag-active {
+    background: #3a3a3a;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
   }
 
   .conversation-empty {

--- a/src/components/ConversationList.tsx
+++ b/src/components/ConversationList.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState, useMemo } from 'preact/hooks';
+import { useEffect, useState, useMemo, useRef } from 'preact/hooks';
 import type { Conversation } from '../types';
 import { ModelSelector } from './ModelSelector';
-import { generatingTitleFor } from '../store';
+import { generatingTitleFor, updateConversationOrders } from '../store';
+import Sortable from 'sortablejs';
 
 interface ConversationListProps {
   conversations: Conversation[];
@@ -41,16 +42,30 @@ export function ConversationList({
   const [editTitle, setEditTitle] = useState('');
   const [activeTab, setActiveTab] = useState<'active' | 'archived'>('active');
   const [searchQuery, setSearchQuery] = useState('');
+  
+  // Refs for sortable containers
+  const activeListRef = useRef<HTMLDivElement>(null);
+  const archivedListRef = useRef<HTMLDivElement>(null);
+  const sortableInstanceRef = useRef<Sortable | null>(null);
 
-  // Filter conversations based on tab and search query
+  // Filter and sort conversations based on tab and search query
   const filteredConversations = useMemo(() => {
     const isArchived = activeTab === 'archived';
-    return conversations.filter(conv => {
+    const filtered = conversations.filter(conv => {
       // Handle undefined archived field (treat as not archived)
       const matchesTab = isArchived ? conv.archived === true : conv.archived !== true;
       const matchesSearch = searchQuery === '' || 
         conv.title.toLowerCase().includes(searchQuery.toLowerCase());
       return matchesTab && matchesSearch;
+    });
+    
+    // Sort by displayOrder (ascending), fallback to updatedAt (descending)
+    return filtered.sort((a, b) => {
+      if (a.displayOrder !== undefined && b.displayOrder !== undefined) {
+        return a.displayOrder - b.displayOrder;
+      }
+      // Fallback to updatedAt for conversations without displayOrder
+      return (b.updatedAt || 0) - (a.updatedAt || 0);
     });
   }, [conversations, activeTab, searchQuery]);
 
@@ -65,6 +80,72 @@ export function ConversationList({
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
+
+  // Initialize Sortable for drag and drop
+  useEffect(() => {
+    const container = activeTab === 'active' ? activeListRef.current : archivedListRef.current;
+    
+    if (container && filteredConversations.length > 0) {
+      // Destroy previous instance if it exists
+      if (sortableInstanceRef.current) {
+        sortableInstanceRef.current.destroy();
+        sortableInstanceRef.current = null;
+      }
+
+      // Small delay to ensure DOM is ready
+      setTimeout(() => {
+        if (!container) return;
+        
+        console.log('Initializing Sortable for', activeTab, 'tab with', filteredConversations.length, 'conversations');
+        
+        // Create new Sortable instance
+        sortableInstanceRef.current = Sortable.create(container, {
+          animation: 150,
+          handle: '.drag-handle',
+          ghostClass: 'conversation-drag-ghost',
+          chosenClass: 'conversation-drag-chosen',
+          dragClass: 'conversation-drag-active',
+          draggable: '.conversation-item',  // Explicitly specify draggable elements
+          forceFallback: true,  // Force fallback for better compatibility
+          onEnd: async (evt) => {
+            console.log('Drag ended:', { oldIndex: evt.oldIndex, newIndex: evt.newIndex });
+            
+            if (evt.oldIndex === undefined || evt.newIndex === undefined) return;
+            if (evt.oldIndex === evt.newIndex) return;
+            
+            // Get all conversation IDs in the current tab
+            const allConversations = conversations.filter(c => 
+              activeTab === 'active' ? !c.archived : c.archived
+            );
+            
+            console.log('Reordering conversations:', allConversations.length, 'total');
+            
+            // Reorder the conversations array
+            const movedItem = allConversations[evt.oldIndex];
+            const reordered = [...allConversations];
+            reordered.splice(evt.oldIndex, 1);
+            reordered.splice(evt.newIndex, 0, movedItem);
+            
+            // Get the IDs in new order
+            const reorderedIds = reordered.map(c => c.id);
+            
+            console.log('New order IDs:', reorderedIds);
+            
+            // Update the order in the store
+            await updateConversationOrders(reorderedIds);
+          }
+        });
+      }, 100);
+    }
+
+    // Cleanup on unmount or when dependencies change
+    return () => {
+      if (sortableInstanceRef.current) {
+        sortableInstanceRef.current.destroy();
+        sortableInstanceRef.current = null;
+      }
+    };
+  }, [activeTab, filteredConversations, conversations]);
 
   const handleRename = (conversation: Conversation) => {
     setEditingId(conversation.id);
@@ -138,12 +219,21 @@ export function ConversationList({
           </div>
         )}
       </div>
-      <div class="conversations">
+      <div 
+        class="conversations"
+        ref={activeTab === 'active' ? activeListRef : archivedListRef}
+      >
         {filteredConversations.map((conversation) => (
           <div
             key={conversation.id}
+            data-conversation-id={conversation.id}
             class={`conversation-item ${selectedId === conversation.id ? 'selected' : ''}`}
           >
+            <div class="drag-handle" title="Drag to reorder">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="drag-icon">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 9h16.5m-16.5 6.75h16.5" />
+              </svg>
+            </div>
             {editingId === conversation.id ? (
               <input
                 type="text"

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -180,13 +180,17 @@ export async function createConversation(
   title: string,
   model?: string
 ): Promise<ConversationType> {
+  // Get the highest display order for new conversation
+  const maxOrder = Math.max(0, ...conversations.value.map(c => c.displayOrder || 0));
+  
   const newConversation: ConversationType = {
     id: Date.now().toString(),
     title,
     model: model || settings.value.defaultModel,
     messages: [],
     createdAt: Date.now(),
-    updatedAt: Date.now()
+    updatedAt: Date.now(),
+    displayOrder: maxOrder + 1
   };
 
   try {
@@ -614,6 +618,29 @@ export function removeMCPServer(serverId: string) {
 
 export function clearMCPServers() {
   mcpServers.value = [];
+}
+
+// Update conversation display orders after drag and drop
+export async function updateConversationOrders(conversationIds: string[]) {
+  try {
+    // Update in-memory state
+    const updatedConversations = conversations.value.map(conv => {
+      const newOrder = conversationIds.indexOf(conv.id);
+      if (newOrder !== -1) {
+        return { ...conv, displayOrder: newOrder };
+      }
+      return conv;
+    });
+    
+    conversations.value = updatedConversations;
+    
+    // Save updated orders to database
+    const { updateConversationOrders: updateOrdersInDB } = await import('../utils/sqlStorage');
+    await updateOrdersInDB(conversationIds);
+  } catch (error) {
+    console.error('Failed to update conversation orders:', error);
+    showError(`Failed to update conversation order: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
 }
 
 export function toggleConversationTool(conversationId: string, serverId: string, toolName: string, enabled: boolean) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface Conversation {
   sdkMessages?: CoreMessage[];
   archived?: boolean;
   archivedAt?: number;
+  displayOrder?: number; // Order for drag and drop sorting
 }
 
 export interface Model {

--- a/src/utils/sqlStorage.ts
+++ b/src/utils/sqlStorage.ts
@@ -202,11 +202,12 @@ class SqlStorage {
       if (conversationsData) {
         const conversations = JSON.parse(conversationsData) as Conversation[];
         
-        for (const conv of conversations) {
+        for (let index = 0; index < conversations.length; index++) {
+          const conv = conversations[index];
           await database.execute(
             `INSERT OR REPLACE INTO conversations 
-             (id, title, model, enabled_tools, archived, archived_at, created_at, updated_at) 
-             VALUES (?, ?, ?, ?, ?, ?, datetime(?, 'unixepoch', 'localtime'), datetime(?, 'unixepoch', 'localtime'))`,
+             (id, title, model, enabled_tools, archived, archived_at, created_at, updated_at, display_order) 
+             VALUES (?, ?, ?, ?, ?, ?, datetime(?, 'unixepoch', 'localtime'), datetime(?, 'unixepoch', 'localtime'), ?)`,
             [
               conv.id,
               conv.title,
@@ -215,7 +216,8 @@ class SqlStorage {
               conv.archived ? 1 : 0,
               conv.archivedAt ? new Date(conv.archivedAt).toISOString() : null,
               (conv.createdAt / 1000).toString(),
-              (conv.updatedAt / 1000).toString()
+              (conv.updatedAt / 1000).toString(),
+              index
             ]
           );
 
@@ -446,8 +448,8 @@ export async function saveSingleConversation(conversation: Conversation): Promis
       // Update or insert the conversation
         await database.execute(
           `INSERT OR REPLACE INTO conversations 
-         (id, title, model, enabled_tools, archived, archived_at, created_at, updated_at) 
-         VALUES (?, ?, ?, ?, ?, ?, datetime(?, 'unixepoch', 'localtime'), datetime(?, 'unixepoch', 'localtime'))`,
+         (id, title, model, enabled_tools, archived, archived_at, created_at, updated_at, display_order) 
+         VALUES (?, ?, ?, ?, ?, ?, datetime(?, 'unixepoch', 'localtime'), datetime(?, 'unixepoch', 'localtime'), ?)`,
           [
             conversation.id,
             conversation.title,
@@ -456,7 +458,8 @@ export async function saveSingleConversation(conversation: Conversation): Promis
             conversation.archived ? 1 : 0,
             conversation.archivedAt ? new Date(conversation.archivedAt).toISOString() : null,
             (conversation.createdAt / 1000).toString(),
-            (conversation.updatedAt / 1000).toString()
+            (conversation.updatedAt / 1000).toString(),
+            conversation.displayOrder || 0
           ]
         );
       
@@ -563,8 +566,9 @@ export async function loadConversations(): Promise<Conversation[]> {
       archived_at: string | null;
       created_at: string;
       updated_at: string;
+      display_order: number;
     }[]>(
-      'SELECT * FROM conversations ORDER BY updated_at DESC'
+      'SELECT * FROM conversations ORDER BY display_order ASC, updated_at DESC'
     );
     
     debugLog('LOAD_CONVERSATIONS: Query complete', { conversationCount: conversations.length });
@@ -632,7 +636,8 @@ export async function loadConversations(): Promise<Conversation[]> {
         archived: Boolean(conv.archived),
         archivedAt: conv.archived_at ? new Date(conv.archived_at).getTime() : undefined,
         createdAt: new Date(conv.created_at).getTime(),
-        updatedAt: new Date(conv.updated_at).getTime()
+        updatedAt: new Date(conv.updated_at).getTime(),
+        displayOrder: conv.display_order
       });
     }
     
@@ -787,8 +792,8 @@ async function saveConversationsInternal(conversations: Conversation[]): Promise
           // Save conversation
           await database.execute(
             `INSERT OR REPLACE INTO conversations 
-             (id, title, model, enabled_tools, archived, archived_at, created_at, updated_at) 
-             VALUES (?, ?, ?, ?, ?, ?, datetime(?, 'unixepoch', 'localtime'), datetime(?, 'unixepoch', 'localtime'))`,
+             (id, title, model, enabled_tools, archived, archived_at, created_at, updated_at, display_order) 
+             VALUES (?, ?, ?, ?, ?, ?, datetime(?, 'unixepoch', 'localtime'), datetime(?, 'unixepoch', 'localtime'), ?)`,
             [
               conv.id,
               conv.title,
@@ -797,7 +802,8 @@ async function saveConversationsInternal(conversations: Conversation[]): Promise
               conv.archived ? 1 : 0,
               conv.archivedAt ? new Date(conv.archivedAt).toISOString() : null,
               (conv.createdAt / 1000).toString(),
-              (conv.updatedAt / 1000).toString()
+              (conv.updatedAt / 1000).toString(),
+              conv.displayOrder || 0
             ]
           );
 
@@ -1138,5 +1144,29 @@ export async function loadRecentPrompts(limit: number = 10): Promise<Prompt[]> {
     console.error('Failed to load recent prompts:', error);
     showError(`Failed to load recent prompts: ${error instanceof Error ? error.message : 'Unknown error'}`);
     return [];
+  }
+}
+
+// Update conversation display orders after drag and drop
+export async function updateConversationOrders(conversationIds: string[]): Promise<void> {
+  debugLog('UPDATE_CONVERSATION_ORDERS: Starting update', { count: conversationIds.length });
+  try {
+    await sqlStorage.init();
+    const database = await getDatabase();
+    
+    // Update each conversation with its new display order
+    for (let i = 0; i < conversationIds.length; i++) {
+      await database.execute(
+        'UPDATE conversations SET display_order = ? WHERE id = ?',
+        [i, conversationIds[i]]
+      );
+    }
+    
+    debugLog('UPDATE_CONVERSATION_ORDERS: Successfully updated orders');
+  } catch (error) {
+    debugLog('UPDATE_CONVERSATION_ORDERS: Failed to update', { error });
+    console.error('Failed to update conversation orders:', error);
+    showError(`Failed to update conversation order: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    throw error;
   }
 }


### PR DESCRIPTION
## Summary
- Implement drag and drop functionality to reorder conversations in the sidebar
- Add persistent conversation ordering that survives app restarts
- Support reordering for both active and archived conversations

## Changes
- **Database**: Added `display_order` column via migration to store conversation order
- **Types**: Extended Conversation interface with `displayOrder` field
- **Dependencies**: Added SortableJS library for drag and drop functionality
- **UI**: Implemented drag handles with visual feedback and animations
- **Store**: Added logic to update and persist conversation orders
- **Styling**: Added CSS for drag states with dark mode support

## Test plan
- [x] Verify drag handle appears on conversation items
- [x] Test dragging conversations to reorder them
- [x] Confirm order persists after app restart
- [x] Test both active and archived conversation reordering
- [x] Verify visual feedback during drag operations
- [x] Check dark mode drag and drop styling

## Screenshots
The implementation adds a drag handle (≡) to each conversation item that allows users to drag and reorder conversations. The order is saved to the database and persists across sessions.

🤖 Generated with [Claude Code](https://claude.ai/code)