### PR TITLE
Hide thinking blocks from conversation UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixes streaming content display when using proxies like those handling claude-sonnet-4-5 with multiple provider backends
 
 ### Changed
+- Hide thinking blocks from conversation UI while keeping backend processing
+  - Thinking blocks no longer visible in conversation view
+  - Thinking amount controls remain functional
+  - Stream processing and parameter passing continue to work
+  - Existing thinking messages in database are preserved but filtered from display
 - Fix responses API detection to use explicit allowlist instead of broad assumptions
   - Renamed `OPENAI_MODELS` to `RESPONSES_API_MODELS` for clarity
   - Now only models explicitly known to support responses API are treated as such

--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -209,14 +209,16 @@ export function Conversation({ conversation, onSendMessage, onRetryMessage, onDe
       </div>
       <div class="conversation-messages" ref={messagesContainerRef}>
         <div class="conversation-messages-content">
-          {conversation.messages.map((message) => (
-            <Message 
-              key={message.id} 
-              message={message}
-              onRetry={() => handleRetry(message.id)}
-              onDelete={() => handleDelete(message.id)}
-            />
-          ))}
+          {conversation.messages
+            .filter((message) => !message.isThinking)
+            .map((message) => (
+              <Message
+                key={message.id}
+                message={message}
+                onRetry={() => handleRetry(message.id)}
+                onDelete={() => handleDelete(message.id)}
+              />
+            ))}
           <div ref={messagesEndRef} />
         </div>
         {showScrollButton && (

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -64,12 +64,6 @@ export function Message({ message, collapsed = true, onRetry, onDelete }: Messag
     }
   }, [message.toolResult, message.content, message.role]);
 
-  // Auto-collapse thinking messages when generation is complete
-  useEffect(() => {
-    if (message.isThinking && !message.isGenerating && !isCollapsed) {
-      setIsCollapsed(true);
-    }
-  }, [message.isThinking, message.isGenerating, isCollapsed]);
 
   const getLoadingAnimation = () => {
     const frames = ['⠋', '⠙', '⠹', '⠸'];
@@ -116,32 +110,6 @@ export function Message({ message, collapsed = true, onRetry, onDelete }: Messag
   };
 
   const renderContent = () => {
-    if (message.isThinking) {
-      return (
-        <div class={`message-content thinking-message ${isCollapsed ? 'collapsed' : ''}`}>
-          <div class="thinking-header" onClick={() => setIsCollapsed(!isCollapsed)}>
-            <span class="thinking-icon">💭</span>
-            <span class="thinking-label">{isCollapsed ? 'Thinking' : 'Thinking...'}</span>
-            <span class="thinking-toggle">{isCollapsed ? '▶' : '▼'}</span>
-          </div>
-          {!isCollapsed && (
-            <div class="thinking-content">
-              {message.isGenerating && !message.content && (
-                <div style={{ color: '#999' }}>
-                  {getLoadingAnimation()}
-                </div>
-              )}
-              {message.content && (
-                <div class="thinking-text">
-                  {message.content}
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      );
-    }
-
     if (message.role === 'tool') {
       return (
         <div class={`message-content tool-message ${isCollapsed ? 'collapsed' : ''}`}>


### PR DESCRIPTION
## Summary
- Hide thinking blocks from conversation view while keeping backend processing intact
- Filter out messages with `isThinking === true` in Conversation component
- Remove thinking block rendering UI from Message component
- Remove auto-collapse effect for thinking messages

## Implementation Details
- Added filter in `Conversation.tsx:212-213` to exclude thinking messages from rendering
- Removed thinking block rendering logic from `Message.tsx:119-143`
- Removed auto-collapse useEffect from `Message.tsx:67-72`
- Updated CHANGELOG.md with user-facing changes

## What Stays Unchanged
- ✓ Stream processing for reasoning events (start/delta/end) continues to work
- ✓ ThinkingAmountSelector component remains functional
- ✓ Thinking parameters still sent to AI APIs
- ✓ Existing thinking messages preserved in database
- ✓ Messages simply filtered at render time

## Test Plan
- [x] All tests pass (250 tests)
- [x] Linting passes with no errors
- [x] Verified conversations load without thinking blocks
- [x] Confirmed thinking amount selector still appears for thinking models
- [x] Backend stream processing continues to function

🤖 Generated with [Claude Code](https://claude.com/claude-code)